### PR TITLE
autodisable curl tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+tab_width = 8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{c,h,in,lua}]
+max_line_length = 100
+
+[{Makefile,**/Makefile,runtime/doc/*.txt}]
+indent_style = tab
+indent_size = 8

--- a/test/auto/db_spec.lua
+++ b/test/auto/db_spec.lua
@@ -546,6 +546,10 @@ describe("sqlite.db", function()
   end)
 
   describe(":select", function()
+    if vim.fn.executable("curl") then
+        pending("'curl' program is not available")
+        return
+    end
     local db = sql:open(path)
     local posts, users
 


### PR DESCRIPTION
- added .editorconfig
- tests: autodisable test in absence of curl
